### PR TITLE
fix: update Dockerfile CMD path for application entry point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,5 +73,5 @@ EXPOSE 8086
 ENTRYPOINT ["dumb-init", "--"]
 
 # Start the application
-CMD ["node", "dist/main"]
+CMD ["node", "dist/src/main"]
     


### PR DESCRIPTION
- Changed the CMD instruction in the Dockerfile to point to the correct application entry point at `dist/src/main` instead of `dist/main`.